### PR TITLE
[LG-24] Code clean up input image type reference

### DIFF
--- a/src/linc_detection.py
+++ b/src/linc_detection.py
@@ -1,6 +1,5 @@
 import os
 
-from PIL import Image as PILImage
 import bentoml
 from bentoml.io import JSON, Image
 from linc_detection_runnable import LincDetectionRunnable
@@ -26,7 +25,7 @@ def authenticate_bearer_token(request):
 
 
 @svc.api(input=Image(), output=JSON(), route='/v1/annotate')
-async def predict(image: PILImage, ctx: bentoml.Context) -> LincDetectionResponse:
+async def predict(image: Image, ctx: bentoml.Context) -> LincDetectionResponse:
     try:
 
         is_authenticated = authenticate_bearer_token(ctx.request)


### PR DESCRIPTION
Wasn't able to repro the error in [LG-24](https://shihlee.atlassian.net/browse/LG-24) locally, the image annotate executes as expected. I did notice though that I was importing Image as PILImage which wasn't necessary, I removed that, reran and everything works as expected. Going to deploy these changes and see if that helps. 