### PR TITLE
fix: handle situation in which no lion features are detected without hanging

### DIFF
--- a/src/adapter/predictor.py
+++ b/src/adapter/predictor.py
@@ -61,6 +61,12 @@ class Predictor:
         if len(top_scores) > 0:
             logger.info(f'Number of detected objects: {len(top_scores)}')
             box_coordinates = fetch_boxes_coordinates(tensor_image, top_boxes, top_labels, label_names)
-            return {"box_coordinates": box_coordinates}
+            return {
+                "message": f"Number of successfullydetected objects: {len(top_scores)}",
+                "box_coordinates": box_coordinates
+            }
         else:
-            return {"error": "No objects detected with confidence above the threshold."}
+            return {
+                "message": "No objects detected with confidence above the threshold.",
+                "box_coordinates": []
+            }

--- a/src/adapter/predictor.py
+++ b/src/adapter/predictor.py
@@ -58,15 +58,15 @@ class Predictor:
         top_boxes = outputs[0]['boxes'][top_scores_filter]
         top_labels = outputs[0]['labels'][top_scores_filter]
 
+        logger.info(f'Number of detected objects: {len(top_scores)}')
         if len(top_scores) > 0:
-            logger.info(f'Number of detected objects: {len(top_scores)}')
             box_coordinates = fetch_boxes_coordinates(tensor_image, top_boxes, top_labels, label_names)
             return {
-                "message": f"Number of successfullydetected objects: {len(top_scores)}",
+                "message": f"Number of successfully detected objects: {len(top_scores)}",
                 "box_coordinates": box_coordinates
             }
         else:
             return {
                 "message": "No objects detected with confidence above the threshold.",
-                "box_coordinates": []
+                "box_coordinates": {}
             }

--- a/src/domain/linc_detection_response.py
+++ b/src/domain/linc_detection_response.py
@@ -4,3 +4,4 @@ from pydantic import BaseModel
 class LincDetectionResponse(BaseModel):
     bounding_box_coords: Optional[Dict[str, List[float]]] = None
     error_message: Optional[str] = None
+    message: Optional[str] = None

--- a/src/linc_detection.py
+++ b/src/linc_detection.py
@@ -37,12 +37,16 @@ async def predict(image: Image, ctx: bentoml.Context) -> LincDetectionResponse:
         prediction_result = await linc_detector_runner.inference.async_run(image)
 
         # Assuming prediction_result is a dictionary containing the bounding box coordinates
-        bounding_box_coords = prediction_result.get("box_coordinates", None)
+        bounding_box_coords = prediction_result.get("box_coordinates", [])
+        message = prediction_result.get("message", "")
 
-        return LincDetectionResponse(bounding_box_coords=bounding_box_coords)
+        return LincDetectionResponse(
+            bounding_box_coords=bounding_box_coords,
+            message=message
+        )
 
-    except Exception:
-
+    except Exception as e:
+        logger.error(f"Error during prediction: {str(e)}")
         ctx.response.status_code = 500
-        # Return LincDetectionResponse with an error message in the error case
-        return LincDetectionResponse(bounding_box_coords=None, error_message="No lion detected in image")
+        # Return LincDetectionResponse with the actual error message
+        return LincDetectionResponse(bounding_box_coords=[], error_message=f"Error during prediction: {str(e)}")

--- a/src/linc_detection.py
+++ b/src/linc_detection.py
@@ -31,22 +31,21 @@ async def predict(image: Image, ctx: bentoml.Context) -> LincDetectionResponse:
         is_authenticated = authenticate_bearer_token(ctx.request)
         if not is_authenticated:
             ctx.response.status_code = 401
-            return LincDetectionResponse(bounding_box_coords=None, error_message="Unauthorized")
+            return LincDetectionResponse(bounding_box_coords={}, error_message="Unauthorized")
 
         # Call predict method to get predictions
         prediction_result = await linc_detector_runner.inference.async_run(image)
 
         # Assuming prediction_result is a dictionary containing the bounding box coordinates
-        bounding_box_coords = prediction_result.get("box_coordinates", [])
-        message = prediction_result.get("message", "")
+        bounding_box_coords = prediction_result["box_coordinates"]
+        message = prediction_result["message"]
 
         return LincDetectionResponse(
             bounding_box_coords=bounding_box_coords,
             message=message
         )
-
     except Exception as e:
         logger.error(f"Error during prediction: {str(e)}")
         ctx.response.status_code = 500
         # Return LincDetectionResponse with the actual error message
-        return LincDetectionResponse(bounding_box_coords=[], error_message=f"Error during prediction: {str(e)}")
+        return LincDetectionResponse(bounding_box_coords={}, error_message=f"Error during prediction: {str(e)}")


### PR DESCRIPTION
https://shihlee.atlassian.net/jira/software/projects/LG/boards/1?selectedIssue=LG-48

Verified w/ local linc-api, linc-webapp, linc-detector-api that the provided image fails prior to this PR, because linc-api cannot handle `bounding_box_coords=None` in the response that gets returned. This PR fixes that by returning an empty dict in that case, as well as adding some messages to go along with what gets returned. The new behavior is that when autocropper fails to detect anything, the image is shown with no autocropped bounding boxes, and the app does not crash.

Also verified that this still works for an image with valid lion features to detect.

We could solve the same problem an alternate way by changing how linc-web deals with bounding box coordinates = None ([link to relevant line of code](https://github.com/linc-lion/linc-webapp/blob/c3e4d85039bb9d59716886f8df086e715dda6f00/app/static/js/controllers/autocropper.uploadimages.controller.js#L111)) but I think always returning a dictionary is cleaner.
